### PR TITLE
Sticky theme names

### DIFF
--- a/.build/template-top.html
+++ b/.build/template-top.html
@@ -73,6 +73,11 @@
                 line-height:1em;
                 letter-spacing:0.2em;
             }
+            
+            body > h1 {
+                position: sticky;
+                top: 0;
+            }
 
             .intro {
                 padding:10em 1em 5em 1em;


### PR DESCRIPTION
Using `body > ` because the logo's a `h1` too, and don't want to include that.

Video: https://i.imgur.com/9NjntJ0.mp4

Was going to build the file too, but Docker :P